### PR TITLE
feat(match): implémentation complète useMatchRecommendations (issue #25)

### DIFF
--- a/frontend/src/hooks/useMatchGlobal.ts
+++ b/frontend/src/hooks/useMatchGlobal.ts
@@ -85,11 +85,11 @@ export const useMatchRecommendations = (initialParams?: {
           poster_url: r.poster_url as string | undefined,
           ...((r.metadata as Record<string, unknown>) || {}),
         },
-        // Score simulé si absent (UI attend un pourcentage)
+        // Score déterministe simulé si absent (UI attend un pourcentage)
         compatibility_score:
           typeof r.compatibility_score === "number"
             ? r.compatibility_score
-            : Math.round(60 + Math.random() * 40),
+            : 80, // Valeur fixe pour testabilité et comportement prévisible
       };
     },
     []

--- a/frontend/src/hooks/useMatchGlobal.ts
+++ b/frontend/src/hooks/useMatchGlobal.ts
@@ -127,7 +127,7 @@ export const useMatchRecommendations = (initialParams?: {
         // Retirer l'élément courant et ajuster l'index si nécessaire
         setState((prev) => {
           const newData = prev.data.filter((_, i) => i !== currentIndex);
-            // Ajuster currentIndex pour ne pas sortir des bornes
+          // Ajuster currentIndex pour ne pas sortir des bornes
           setCurrentIndex((prevIdx) => {
             if (newData.length === 0) return 0;
             return Math.min(prevIdx, newData.length - 1);

--- a/frontend/src/hooks/useMatchGlobal.ts
+++ b/frontend/src/hooks/useMatchGlobal.ts
@@ -1,36 +1,171 @@
 /**
- * Hooks pour le mode Match Global
+ * Hooks pour le mode Match Global (version active)
+ * Issue #25: Remplacer le stub de useMatchRecommendations
  */
 
 import { useState, useCallback } from "react";
+import { matchApi } from "../services/matchApi";
+import { useErrorHandler } from "./useErrorHandler";
 
-// Hook MATCH simplifié neutralisé (refactor en cours)
-export const useMatchRecommendations = () => {
-  const [recommendations] = useState<any[]>([]);
-  const [loading] = useState(false);
-  const [error] = useState<string | null>(null);
-  const fetchRecommendations = useCallback(async () => {}, []);
-  const submitAction = useCallback(async () => true, []);
-  const nextRecommendation = useCallback(() => {}, []);
-  const refresh = useCallback(async () => {}, []);
+// Types dérivés (on enrichit la réponse minimale pour la page Match)
+export interface GlobalMatchRecommendation {
+  external_id: string;
+  title: string;
+  content_type: string; // ex: FILMS / SERIES ... (placeholder tant que normalisation en cours)
+  source: string; // ex: tmdb / spotify...
+  poster_url?: string;
+  description?: string;
+  metadata?: ({
+    description?: string;
+    poster_url?: string;
+  } & Record<string, unknown>);
+  compatibility_score?: number;
+}
+
+interface AsyncState<T> {
+  data: T;
+  loading: boolean;
+  error: string | null;
+}
+
+interface UseMatchRecommendationsReturn {
+  recommendations: GlobalMatchRecommendation[];
+  loading: boolean;
+  error: string | null;
+  fetchRecommendations: (params?: { category?: string; count?: number }) => Promise<void>;
+  submitAction: (action?: "like" | "dislike" | "add") => Promise<boolean>;
+  currentIndex: number;
+  nextRecommendation: () => void;
+  hasMore: boolean;
+  refresh: () => Promise<void>;
+}
+
+export const useMatchRecommendations = (
+  initialParams?: { category?: string; count?: number }
+): UseMatchRecommendationsReturn => {
+  const [state, setState] = useState<AsyncState<GlobalMatchRecommendation[]>>({
+    data: [],
+    loading: false,
+    error: null,
+  });
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [lastParams, setLastParams] = useState(initialParams);
+  const { handleError } = useErrorHandler();
+
+  const mapRawToRecommendation = useCallback(
+    (raw: unknown): GlobalMatchRecommendation => {
+      const r = raw as Record<string, unknown>;
+      // Le service minimal fournit: id, title, category, poster_url?, description?
+      // On complète pour le composant consommateur.
+      const contentType = String(
+        (r.content_type as string) || (r.category as string) || "FILMS"
+      ).toUpperCase();
+      return {
+        external_id:
+          (r.external_id as string) || (r.id as string) || crypto.randomUUID(),
+        title: (r.title as string) || "Contenu sans titre",
+        content_type: contentType,
+        source: (r.source as string) || "tmdb", // défaut temporaire
+        poster_url: r.poster_url as string | undefined,
+        description: r.description as string | undefined,
+        metadata: {
+          description: r.description as string | undefined,
+          poster_url: r.poster_url as string | undefined,
+          ...((r.metadata as Record<string, unknown>) || {}),
+        },
+        // Score simulé si absent (UI attend un pourcentage)
+        compatibility_score:
+          typeof r.compatibility_score === "number"
+            ? (r.compatibility_score as number)
+            : Math.round(60 + Math.random() * 40),
+      };
+    },
+    []
+  );
+
+  const fetchRecommendations = useCallback(
+    async (params?: { category?: string; count?: number }) => {
+      setState((prev) => ({ ...prev, loading: true, error: null }));
+      setLastParams(params);
+      try {
+        const resp = await matchApi.getRecommendations(params);
+        const mapped = (resp.results || []).map(mapRawToRecommendation);
+        setState({ data: mapped, loading: false, error: null });
+        setCurrentIndex(0);
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : "Erreur lors du chargement";
+        setState({ data: [], loading: false, error: msg });
+        handleError(e, "fetchRecommendations");
+      }
+    },
+    [handleError, mapRawToRecommendation]
+  );
+
+  const submitAction = useCallback(
+    async (action: "like" | "dislike" | "add" = "like") => {
+      const current = state.data[currentIndex];
+      if (!current) return false;
+      try {
+        await matchApi.submitAction({
+          external_id: current.external_id,
+          source: current.source,
+          category: current.content_type,
+          action,
+          title: current.title,
+          metadata: current.metadata,
+          description: current.description,
+          poster_url: current.poster_url,
+        });
+        // Retirer l'élément courant et rester sur le même index (qui pointe désormais sur le suivant)
+        setState((prev) => ({
+            ...prev,
+            data: prev.data.filter((_, i) => i !== currentIndex),
+          }));
+        return true;
+      } catch (e) {
+        handleError(e, "submitAction");
+        return false;
+      }
+    },
+    [currentIndex, state.data, handleError]
+  );
+
+  const nextRecommendation = useCallback(() => {
+    setCurrentIndex((prev) => {
+      const next = prev + 1;
+      if (next >= state.data.length - 2 && state.data.length > 0) {
+        // Pré-chargement lorsque l'on approche de la fin
+        fetchRecommendations(lastParams);
+      }
+      return next;
+    });
+  }, [state.data, fetchRecommendations, lastParams]);
+
+  const refresh = useCallback(async () => {
+    await fetchRecommendations(lastParams);
+  }, [fetchRecommendations, lastParams]);
+
   return {
-    recommendations,
-    loading,
-    error,
+    recommendations: state.data,
+    loading: state.loading,
+    error: state.error,
     fetchRecommendations,
     submitAction,
-    currentIndex: 0,
+    currentIndex,
     nextRecommendation,
-    hasMore: false,
+    hasMore: currentIndex < state.data.length - 1,
     refresh,
   };
 };
 
+// Actions (placeholder amélioré — conserve signature actuelle simple)
 export const useMatchActions = () => ({
   submitAction: async () => true,
   loading: false,
   error: null,
 });
+
+// Stats (toujours mockées pour le moment)
 export const useMatchStats = () => ({
   totalMatches: 0,
   successfulMatches: 0,

--- a/frontend/src/pages/ListsPage.tsx
+++ b/frontend/src/pages/ListsPage.tsx
@@ -166,9 +166,7 @@ const ListsPage: React.FC<ListsPageProps> = ({ onNavigate }) => {
     return item.external_ref?.poster_url || null;
   };
 
-  const getBackdropUrl = (item: ListItem): string | null => {
-    return item.external_ref?.backdrop_url || null;
-  };
+  // backdrops non utilisés actuellement
 
   const getGenres = (item: ListItem): string[] => {
     return item.external_ref?.genres || [];

--- a/frontend/src/pages/MatchPage-full.tsx
+++ b/frontend/src/pages/MatchPage-full.tsx
@@ -111,19 +111,25 @@ const MatchPage: React.FC<MatchPageProps> = ({ onNavigate }) => {
 
   // Fonction pour générer des raisons de compatibilité basées sur les métadonnées
   const getCompatibilityReasons = (item: typeof currentItem) => {
-    if (!item) return [];
-
-    const reasons = [];
-    if (item.metadata?.genre_ids?.length) {
+    if (!item) return [] as string[];
+    const meta = (item.metadata || {}) as Record<string, unknown> & {
+      genre_ids?: unknown;
+      vote_average?: unknown;
+      popularity?: unknown;
+    };
+    const reasons: string[] = [];
+    if (Array.isArray(meta.genre_ids) && meta.genre_ids.length > 0) {
       reasons.push("Genre compatible");
     }
-    if (item.metadata?.vote_average && item.metadata.vote_average > 7) {
+    const vote = typeof meta.vote_average === "number" ? meta.vote_average : undefined;
+    if (vote !== undefined && vote > 7) {
       reasons.push("Très bien noté");
     }
-    if (item.metadata?.popularity && item.metadata.popularity > 100) {
+    const popularity = typeof meta.popularity === "number" ? meta.popularity : undefined;
+    if (popularity !== undefined && popularity > 100) {
       reasons.push("Populaire");
     }
-    if (item.compatibility_score > 80) {
+    if ((item.compatibility_score ?? 0) > 80) {
       reasons.push("Forte compatibilité");
     }
 
@@ -275,7 +281,7 @@ const MatchPage: React.FC<MatchPageProps> = ({ onNavigate }) => {
                         {/* Score de compatibilité en overlay */}
                         <div className="absolute top-4 right-4 bg-white/10 backdrop-blur-md rounded-full px-3 py-2">
                           <p className="text-2xl font-bold text-white">
-                            {Math.round(currentItem.compatibility_score)}%
+                            {Math.round(currentItem.compatibility_score ?? 0)}%
                           </p>
                           <p className="text-xs text-white/80 text-center">
                             Match

--- a/frontend/src/pages/MatchPage-full.tsx
+++ b/frontend/src/pages/MatchPage-full.tsx
@@ -121,11 +121,13 @@ const MatchPage: React.FC<MatchPageProps> = ({ onNavigate }) => {
     if (Array.isArray(meta.genre_ids) && meta.genre_ids.length > 0) {
       reasons.push("Genre compatible");
     }
-    const vote = typeof meta.vote_average === "number" ? meta.vote_average : undefined;
+    const vote =
+      typeof meta.vote_average === "number" ? meta.vote_average : undefined;
     if (vote !== undefined && vote > 7) {
       reasons.push("Très bien noté");
     }
-    const popularity = typeof meta.popularity === "number" ? meta.popularity : undefined;
+    const popularity =
+      typeof meta.popularity === "number" ? meta.popularity : undefined;
     if (popularity !== undefined && popularity > 100) {
       reasons.push("Populaire");
     }

--- a/frontend/src/services/cacheService.ts
+++ b/frontend/src/services/cacheService.ts
@@ -12,19 +12,19 @@ class CacheService {
     this.cache.set(key, {
       data,
       timestamp: Date.now(),
-      ttl
+      ttl,
     });
   }
 
   get<T>(key: string): T | null {
     const item = this.cache.get(key);
-    
+
     if (!item) {
       return null;
     }
 
     const isExpired = Date.now() - item.timestamp > item.ttl;
-    
+
     if (isExpired) {
       this.cache.delete(key);
       return null;
@@ -47,11 +47,11 @@ class CacheService {
 
   // Méthodes utilitaires pour les clés de cache
   generateSearchKey(query: string, category?: string, limit?: number): string {
-    return `search:${query}:${category || 'all'}:${limit || 8}`;
+    return `search:${query}:${category || "all"}:${limit || 8}`;
   }
 
   generateSuggestionsKey(category?: string, limit?: number): string {
-    return `suggestions:${category || 'all'}:${limit || 6}`;
+    return `suggestions:${category || "all"}:${limit || 6}`;
   }
 
   generateListKey(listId: number): string {
@@ -71,7 +71,7 @@ class CacheService {
   invalidateSearch(): void {
     // Supprimer toutes les clés de recherche
     for (const key of this.cache.keys()) {
-      if (key.startsWith('search:')) {
+      if (key.startsWith("search:")) {
         this.delete(key);
       }
     }
@@ -80,7 +80,7 @@ class CacheService {
   invalidateSuggestions(): void {
     // Supprimer toutes les clés de suggestions
     for (const key of this.cache.keys()) {
-      if (key.startsWith('suggestions:')) {
+      if (key.startsWith("suggestions:")) {
         this.delete(key);
       }
     }
@@ -92,7 +92,7 @@ class CacheService {
     let validEntries = 0;
     let expiredEntries = 0;
 
-  for (const [, item] of this.cache.entries()) {
+    for (const [, item] of this.cache.entries()) {
       if (now - item.timestamp > item.ttl) {
         expiredEntries++;
       } else {
@@ -103,7 +103,7 @@ class CacheService {
     return {
       total: this.cache.size,
       valid: validEntries,
-      expired: expiredEntries
+      expired: expiredEntries,
     };
   }
 

--- a/frontend/src/services/cacheService.ts
+++ b/frontend/src/services/cacheService.ts
@@ -92,7 +92,7 @@ class CacheService {
     let validEntries = 0;
     let expiredEntries = 0;
 
-    for (const [key, item] of this.cache.entries()) {
+  for (const [, item] of this.cache.entries()) {
       if (now - item.timestamp > item.ttl) {
         expiredEntries++;
       } else {
@@ -110,9 +110,9 @@ class CacheService {
   // Nettoyage automatique des entrées expirées
   cleanup(): void {
     const now = Date.now();
-    for (const [key, item] of this.cache.entries()) {
+    for (const [k, item] of this.cache.entries()) {
       if (now - item.timestamp > item.ttl) {
-        this.cache.delete(key);
+        this.cache.delete(k);
       }
     }
   }


### PR DESCRIPTION
Résolution de l’issue #25.\n\nChangements principaux:\n- Remplacement du stub de useMatchRecommendations par une implémentation fonctionnelle.\n- Intégration avec matchApi minimal (getRecommendations + submitAction).\n- Gestion state data/loading/error + refresh.\n- Retrait de la recommandation après action, pré-chargement anticipé.\n- Simulation score de compatibilité si absent (60–100) pour UI.\n- Typage local transitoire GlobalMatchRecommendation.\n- Sécurisation TS partielle (MatchPage-full, cacheService cleanup).\n\nNon inclus (hors scope):\n- Action skip côté API (non supportée pour l’instant).\n- Tests unitaires (infra de test React non encore configurée).\n- Normalisation complète des types (à faire ultérieurement).\n\nNotes techniques:\n- Préfetch quand index >= length - 2.\n- refresh() relance la dernière requête (params mémorisés).\n- Fichier de notes interne ignoré: work_notes_B5_remplacer_stub_useMatchRecommendations.md.\n\nCloses #25\n\nReviewers:\n@GitHub Copilot merci pour une review ciblée (focus: logique, edge cases d’état vide/erreur).