### PR TITLE
C1 #28: Endpoint profil social /social/profile/me

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,4 @@ docs/
 work_notes_*.md
 backend/LOGGING_NOTES_INTERNAL.md
 issue_27_rate_limiting_notes.md
+issue_28_social_profile_notes.md

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -199,9 +199,10 @@ class SocialProfileSerializer(serializers.ModelSerializer):
         )
         read_only_fields = fields
 
-    def get_stats(self, obj):  # type: ignore[override]
-        # Comptage des amis acceptés
-        friends_count = len(Friendship.get_friends(obj.user))
+    def get_stats(self, obj):
+        # Comptage des amis acceptés (get_friends retourne déjà une liste)
+        friends = Friendship.get_friends(obj.user)
+        friends_count = len(friends)
         # Demandes reçues en attente
         pending_requests = Friendship.objects.filter(
             addressee=obj.user,

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -1,7 +1,7 @@
 from django.contrib.auth.models import User
 from rest_framework import serializers
 from django.contrib.auth.password_validation import validate_password
-from .models import List, ListItem, ExternalReference, UserPreference
+from .models import List, ListItem, ExternalReference, UserPreference, UserProfile, Friendship
 
 class RegisterSerializer(serializers.ModelSerializer):
     password = serializers.CharField(
@@ -181,3 +181,36 @@ class MatchActionSerializer(serializers.Serializer):
         return super().to_internal_value(data)
 
     # Pas de create/update: ce serializer est strictement pour validation d'entrée.
+
+
+class SocialProfileSerializer(serializers.ModelSerializer):
+    """Serializer pour exposer le profil social + statistiques agrégées.
+    Fournit friends_count & pending_requests dynamiquement (pas stockés dans UserProfile).
+    """
+    user_id = serializers.IntegerField(source='user.id', read_only=True)
+    username = serializers.CharField(source='user.username', read_only=True)
+    stats = serializers.SerializerMethodField()
+
+    class Meta:
+        model = UserProfile
+        fields = (
+            'user_id', 'username', 'gamertag', 'display_name', 'bio', 'avatar_url',
+            'is_public', 'stats', 'created_at'
+        )
+        read_only_fields = fields
+
+    def get_stats(self, obj):  # type: ignore[override]
+        # Comptage des amis acceptés
+        friends_count = len(Friendship.get_friends(obj.user))
+        # Demandes reçues en attente
+        pending_requests = Friendship.objects.filter(
+            addressee=obj.user,
+            status=Friendship.Status.PENDING
+        ).count()
+        return {
+            'total_matches': obj.total_matches,
+            'successful_matches': obj.successful_matches,
+            'friends_count': friends_count,
+            'pending_requests': pending_requests
+        }
+

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -9,7 +9,7 @@ from .views import (
     get_trending_suggestions, get_similar_suggestions,
     # Match Global + Social endpoints
     get_match_recommendations, submit_match_action,
-    get_user_social_profile, update_user_social_profile,
+    get_user_social_profile, get_user_social_profile_me, update_user_social_profile,
     add_friend_by_gamertag, get_friends_list, get_friend_requests,
     respond_friend_request, search_user_by_gamertag, delete_friend,
     create_versus_match, get_versus_matches,
@@ -50,7 +50,8 @@ urlpatterns = [
     path('match/action/', submit_match_action, name='submit_match_action'),
     
     # Social Profile endpoints
-    path('social/profile/', get_user_social_profile, name='social_profile'),
+    path('social/profile/', get_user_social_profile, name='social_profile'),  # legacy
+    path('social/profile/me/', get_user_social_profile_me, name='social_profile_me'),
     path('social/profile/update/', update_user_social_profile, name='update_social_profile'),
     
     # Friends Management endpoints

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1332,44 +1332,43 @@ def get_user_social_profile(request):
     Récupère le profil social de l'utilisateur connecté
     """
     try:
-        from .models import UserProfile, Friendship
-        
-        # Récupérer ou créer le profil
-        profile, created = UserProfile.objects.get_or_create(
-            user=request.user,
-            defaults={
-                'display_name': request.user.username
-            }
-        )
-        
-        # Compter les amis
-        friends_count = len(Friendship.get_friends(request.user))
-        
-        # Compter les demandes en attente
-        pending_requests = Friendship.objects.filter(
-            addressee=request.user,
-            status=Friendship.Status.PENDING
-        ).count()
-        
-        return Response({
-            'user_id': request.user.id,
-            'username': request.user.username,
-            'gamertag': profile.gamertag,
-            'display_name': profile.display_name,
-            'bio': profile.bio,
-            'avatar_url': profile.avatar_url,
-            'is_public': profile.is_public,
-            'stats': {
-                'total_matches': profile.total_matches,
-                'successful_matches': profile.successful_matches,
-                'friends_count': friends_count,
-                'pending_requests': pending_requests
-            },
-            'created_at': profile.created_at
-        })
+                from .models import UserProfile
+                from .serializers import SocialProfileSerializer
+
+                def _serialize(user):
+                    profile, _ = UserProfile.objects.get_or_create(
+                        user=user,
+                        defaults={'display_name': user.username}
+                    )
+                    return SocialProfileSerializer(profile).data
+
+                return Response(_serialize(request.user))
         
     except Exception as e:
         logger.error(f"Social profile error: {e}")
+        return Response(
+            {'error': f'Erreur lors de la récupération du profil: {str(e)}'},
+            status=status.HTTP_500_INTERNAL_SERVER_ERROR
+        )
+
+
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
+@throttle_classes([ScopedRateThrottle])
+def get_user_social_profile_me(request):
+    """Endpoint spécifique C1: GET /social/profile/me
+    Fournit le même payload que /social/profile/ (legacy)."""
+    try:
+        from .models import UserProfile
+        from .serializers import SocialProfileSerializer
+        profile, _ = UserProfile.objects.get_or_create(
+            user=request.user,
+            defaults={'display_name': request.user.username}
+        )
+        data = SocialProfileSerializer(profile).data
+        return Response(data)
+    except Exception as e:
+        logger.error(f"Social profile /me error: {e}")
         return Response(
             {'error': f'Erreur lors de la récupération du profil: {str(e)}'},
             status=status.HTTP_500_INTERNAL_SERVER_ERROR

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1332,18 +1332,14 @@ def get_user_social_profile(request):
     Récupère le profil social de l'utilisateur connecté
     """
     try:
-                from .models import UserProfile
-                from .serializers import SocialProfileSerializer
+        from .models import UserProfile
+        from .serializers import SocialProfileSerializer
+        profile, _ = UserProfile.objects.get_or_create(
+            user=request.user,
+            defaults={'display_name': request.user.username}
+        )
+        return Response(SocialProfileSerializer(profile).data)
 
-                def _serialize(user):
-                    profile, _ = UserProfile.objects.get_or_create(
-                        user=user,
-                        defaults={'display_name': user.username}
-                    )
-                    return SocialProfileSerializer(profile).data
-
-                return Response(_serialize(request.user))
-        
     except Exception as e:
         logger.error(f"Social profile error: {e}")
         return Response(
@@ -1356,8 +1352,7 @@ def get_user_social_profile(request):
 @permission_classes([IsAuthenticated])
 @throttle_classes([ScopedRateThrottle])
 def get_user_social_profile_me(request):
-    """Endpoint spécifique C1: GET /social/profile/me
-    Fournit le même payload que /social/profile/ (legacy)."""
+    """Endpoint spécifique C1: GET /social/profile/me – même payload que /social/profile/."""
     try:
         from .models import UserProfile
         from .serializers import SocialProfileSerializer

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1352,7 +1352,15 @@ def get_user_social_profile(request):
 @permission_classes([IsAuthenticated])
 @throttle_classes([ScopedRateThrottle])
 def get_user_social_profile_me(request):
-    """Endpoint spécifique C1: GET /social/profile/me – même payload que /social/profile/."""
+    """
+    Endpoint spécifique C1: GET /social/profile/me – même payload que /social/profile/.
+
+    Ce endpoint existe en complément de GET /social/profile/ pour des raisons de clarté et de convention RESTful :
+    - /social/profile/ : Utilisé pour récupérer le profil social de l'utilisateur actuellement authentifié. Peut être utilisé dans des contextes où l'identité de l'utilisateur est implicite.
+    - /social/profile/me : Fournit explicitement le profil de l'utilisateur connecté, suivant la convention courante d'API REST où /me désigne toujours l'utilisateur courant. Cela peut faciliter l'intégration côté client, notamment pour des frameworks ou outils qui s'attendent à un endpoint /me.
+
+    Les deux endpoints retournent exactement le même payload (profil social de l'utilisateur authentifié), mais sont exposés pour répondre à différents besoins d'intégration ou de lisibilité côté client.
+    """
     try:
         from .models import UserProfile
         from .serializers import SocialProfileSerializer


### PR DESCRIPTION
Implémentation issue #28 (C1)\n\n- Nouveau serializer SocialProfileSerializer\n- Endpoint GET /social/profile/me/ (legacy conservé)\n- Refactor vues + tests API\n- Doc interne ignorée: issue_28_social_profile_notes.md\n\nTests clés OK (MatchAction, SocialProfile).\n\nMerci pour la review @Copilot